### PR TITLE
Disable mailerpath entirely

### DIFF
--- a/files/sudoers.ubuntu
+++ b/files/sudoers.ubuntu
@@ -7,6 +7,7 @@
 # See the man page for details on how to write a sudoers file.
 #
 Defaults	env_reset
+Defaults	!mailerpath
 Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # Host alias specification


### PR DESCRIPTION
Tested by setting mailto="myname@yelp.com",mail_always. This resulted in
a lot of mail. !mailerpath halted the mail.